### PR TITLE
Fix tests on 32 bit platforms

### DIFF
--- a/src/Data/Thyme/Format.hs
+++ b/src/Data/Thyme/Format.hs
@@ -27,6 +27,7 @@ import Data.Bits
 import qualified Data.ByteString.Char8 as S
 import Data.Char
 import Data.Micro
+import Data.Int
 import Data.Thyme.Calendar
 import Data.Thyme.Calendar.Internal
 import Data.Thyme.Calendar.MonthDay
@@ -358,7 +359,7 @@ timeParser TimeLocale {..} = flip execStateT unixEpoch . go where
             -- UTCTime
             's' -> do
                 s <- lift (negative P.decimal)
-                _tpPOSIXTime .= fromSeconds (s :: Int)
+                _tpPOSIXTime .= fromSeconds (s :: Int64)
                 flag IsPOSIXTime .= True
                 go rspec
 

--- a/tests/Common.hs
+++ b/tests/Common.hs
@@ -4,6 +4,7 @@ module Common where
 import Prelude
 import Control.Applicative
 import Control.Lens
+import Data.Int
 import Data.Thyme
 import System.Exit
 import Test.QuickCheck
@@ -15,7 +16,8 @@ exit b = exitWith $ if b then ExitSuccess else ExitFailure 1
 ------------------------------------------------------------------------
 
 instance Arbitrary Day where
-    arbitrary = ModifiedJulianDay <$> arbitrary
+    -- To avoid overflows in Day --> YearMonthDay conversion on 32 bit platforms:
+    arbitrary = ModifiedJulianDay <$> (fromIntegral :: Int -> Int64) <$> arbitrary
 
 instance Arbitrary DiffTime where
     arbitrary = view microDiffTime <$> arbitrary


### PR DESCRIPTION
The library was failing tests on my 32 bits machine.

Two tests were failing:
1.  prop_showRead :: Day -> Bool. This is just because Day in Int64 internally and YearMonthDay has an Int as year. I limited the range of Days we test to Int.
2. prop_parseTime. This is a real bug; you were parsing '%s' as an Int, which introduced a year 2038 bug to your code.

We did the debugging together with @errge.
