### PR TITLE
Data.Thyme.Calendar.Internal.isLeapYear: simplify and make faster

### DIFF
--- a/src/Data/Thyme/Calendar/Internal.hs
+++ b/src/Data/Thyme/Calendar/Internal.hs
@@ -20,6 +20,7 @@ import Control.DeepSeq
 import Control.Lens
 import Control.Monad
 import Data.AffineSpace
+import Data.Bits ((.&.))
 import Data.Data
 import Data.Int
 import Data.Ix
@@ -30,7 +31,7 @@ import GHC.Generics (Generic)
 import GHC.Prim
 import GHC.Types
 import System.Random
-import Test.QuickCheck
+import Test.QuickCheck hiding ((.&.))
 
 type Years = Int
 type Months = Int
@@ -105,13 +106,9 @@ instance NFData YearMonthDay
 
 -- | Gregorian leap year?
 isLeapYear :: Year -> Bool
-isLeapYear (I# y#) = isLeapYear# y#
-
--- | INTERNAL: avoid GHC duplicating code for each of the possibilities.
-{-# NOINLINE isLeapYear# #-}
-isLeapYear# :: Int# -> Bool
-isLeapYear# y# = remInt# y# 4# ==# 0#
-    && (remInt# y# 400# ==# 0# || remInt# y# 100# /=# 0#)
+isLeapYear y = y .&. 3 == 0  &&  (r100 /= 0 || d100 .&. 3 == 0)
+  where
+    (d100,r100) = y `quotRem` 100
 
 type DayOfYear = Int
 data OrdinalDate = OrdinalDate


### PR DESCRIPTION
This also makes it compile with GHC 7.8 and thus fixes #15.

I looked at this because `thyme` wasn't building with GHC 7.8-rc2, and I realized that it's possible to make this function faster while fixing this. Doing bit operations is _much_ faster than dividing by 4.

I did a quick benchmark and the original code runs in 20-40ns (20 on eg. 1999 - the easiest case, 40 on 1900 - the hardest case). The improved code runs in 10-20ns (halved for both cases).

I was playing with these things recently while working on `tz`. For example I have more than 2 times faster `toOrdinalDate` implementation. I'll send you a few pull requests with these, if you don't mind.
