### PR TITLE
Fix UTC JSON instance.

### DIFF
--- a/src/Data/Thyme/Format/Aeson.hs
+++ b/src/Data/Thyme/Format/Aeson.hs
@@ -88,8 +88,8 @@ instance FromJSON ZonedTime where
     parseJSON v = typeMismatch "ZonedTime" v
 
 instance ToJSON UTCTime where
-    toJSON t = String (pack (take 23 str ++ "Z"))
-      where str = formatTime defaultTimeLocale "%FT%T.%q" t
+    toJSON t = String (pack str)
+      where str = formatTime defaultTimeLocale "%FT%TZ" t
     {-# INLINE toJSON #-}
 
 instance FromJSON UTCTime where


### PR DESCRIPTION
Doing some round-trip testing through CouchDB using the Arbitrary
instances, I was ending up with strings with a superfluous '.' before
the time zone 'Z', which was causing them to fail to be read back in.

These tests have been rock-solid using ZonedTime, but I recently made
the decision to start storing UTCTime, and suddenly failures started
springing up---so I know my round-trip strategy should work.

I removed the storing of millis entirely, and things went back to
working.
