### PR TITLE
Compatibility with GHC 9.8 and 9.10

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os:    [macos-latest, ubuntu-latest]
-        cabal: ["3.8"]
-        ghc:   ["8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.6", "9.4.4"]
+        cabal: ["3.12"]
+        ghc:   ["8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.6", "9.8.4", "9.10.1"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -29,7 +29,7 @@ jobs:
         run: |
           cabal v2-update
           cabal v2-freeze $CONFIG
-      - uses: actions/cache@v2.1.5
+      - uses: actions/cache@v4
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,6 +15,17 @@ jobs:
         os:    [macos-latest, ubuntu-latest]
         cabal: ["3.12"]
         ghc:   ["8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.6", "9.8.4", "9.10.1"]
+        exclude:
+          - os: macos-latest
+            ghc: "8.4.4"
+          - os: macos-latest
+            ghc: "8.6.5"
+          - os: macos-latest
+            ghc: "8.8.4"
+          - os: macos-latest
+            ghc: "8.10.7"
+          - os: macos-latest
+            ghc: "9.0.2"
 
     runs-on: ${{ matrix.os }}
 

--- a/src/Data/Thyme/TrueName.hs
+++ b/src/Data/Thyme/TrueName.hs
@@ -65,7 +65,9 @@ decNames dec = case dec of
     PatSynSigD _name typ -> typNames typ
 #endif
 
-#if MIN_VERSION_template_haskell(2,8,0)
+#if MIN_VERSION_template_haskell(2,22,0)
+    InfixD _ _ _ -> []
+#elif MIN_VERSION_template_haskell(2,8,0)
     InfixD _ _ -> []
 #endif
 
@@ -121,6 +123,11 @@ decNames dec = case dec of
 
 #if MIN_VERSION_template_haskell(2,15,0)
     ImplicitParamBindD _ _ -> []
+#endif
+
+#if MIN_VERSION_template_haskell(2,22,0)
+    TypeDataD _ _ _ _ -> []
+    DefaultD _ -> []
 #endif
 
 {- }}} -}

--- a/thyme.cabal
+++ b/thyme.cabal
@@ -97,7 +97,7 @@ library
         old-locale >= 1.0,
         random,
         text >= 0.11,
-        template-haskell >= 2.7 && < 2.21,
+        template-haskell >= 2.7 && < 2.23,
         time >= 1.4,
         vector >= 0.9,
         vector-th-unbox >= 0.2.1.0,


### PR DESCRIPTION
InfixD change mentioned in breakage inventory: https://github.com/tomjaguarpaw/tilapia/blob/master/breakage-inventory-ghc-9.10.md

See also migration guides:
* https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.6
* https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.8
* https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.10
